### PR TITLE
Fix missing bee-tools in development dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ env:
     - NPM_CONFIG_PROGRESS="false"
 
 before_install:
-  - npm install - g bee-tools
+  - npm install
 
 script:  npm test && npm run browsers

--- a/package.json
+++ b/package.json
@@ -15,36 +15,34 @@
   },
   "homepage": "https://github.com/tinper-bee/bee-grid",
   "author": "zhouboyu",
-
-"repository": "http://github.com/tinper-bee/bee-grid",
-
-"bugs": "https://github.com/tinper-bee/bee-grid/issues",
-"license": "MIT",
-
-"main":"./build/index",
-"config":{
-"port": 8000
-},
-"scripts": {
-"dev": "bee-tools run start",
-"build": "bee-tools run build",
-"lint": "bee-tools run lint",
-"test": "bee-tools run test",
-"chrome": "bee-tools run chrome",
-"browsers": "bee-tools run browsers",
-"pub": "bee-tools run pub"
-},
-"dependencies": {
-  "classnames": "^2.2.5",
-  "tinper-bee-core": "latest"
-},
-"devDependencies": {
-  "chai": "^3.5.0",
-  "enzyme": "^2.4.1",
-  "react": "~0.14.0",
-  "react-addons-test-utils": "^15.3.2",
-  "react-dom": "~0.14.0",
-  "console-polyfill": "~0.2.1",
-  "es5-shim": "~4.1.10"
-}
+  "repository": "http://github.com/tinper-bee/bee-grid",
+  "bugs": "https://github.com/tinper-bee/bee-grid/issues",
+  "license": "MIT",
+  "main": "./build/index",
+  "config": {
+    "port": 8000
+  },
+  "scripts": {
+    "dev": "bee-tools run start",
+    "build": "bee-tools run build",
+    "lint": "bee-tools run lint",
+    "test": "bee-tools run test",
+    "chrome": "bee-tools run chrome",
+    "browsers": "bee-tools run browsers",
+    "pub": "bee-tools run pub"
+  },
+  "dependencies": {
+    "classnames": "^2.2.5",
+    "tinper-bee-core": "latest"
+  },
+  "devDependencies": {
+    "bee-tools": "0.0.16",
+    "chai": "^3.5.0",
+    "console-polyfill": "~0.2.1",
+    "enzyme": "^2.4.1",
+    "es5-shim": "~4.1.10",
+    "react": "~0.14.0",
+    "react-addons-test-utils": "^15.3.2",
+    "react-dom": "~0.14.0"
+  }
 }


### PR DESCRIPTION
Fix follow error when running `npm run dev`

```
npm info it worked if it ends with ok
npm info using npm@3.10.7
npm info using node@v4.5.0
npm info lifecycle bee-grid@0.0.1~predev: bee-grid@0.0.1
npm info lifecycle bee-grid@0.0.1~dev: bee-grid@0.0.1

> bee-grid@0.0.1 dev /home/chenyang/source/_demos_/bee-grid
> bee-tools run start

sh: 1: bee-tools: not found
```